### PR TITLE
Add internationalization support

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -21,5 +21,15 @@
 	"month_september" : { "message": "September" },
 	"month_october" : { "message": "October" },
 	"month_november" : { "message": "November" },
-	"month_december" : { "message": "December" }
+	"month_december" : { "message": "December" },
+
+	"options_title": { "message" : "New Tab Options"},
+	"12_hour": { "message" : "12-hour"},
+	"24_hour": { "message" : "24-hour"},
+	"show_date": { "message" : "Show date"},
+	"change_theme_daytime": { "message" : "Change theme by time of day"},
+	"light": { "message" : "Light"},
+	"night": { "message" : "Night"},
+	"dark": { "message" : "Dark"},
+	"material": { "message" : "Material"}
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,25 @@
+{
+	"extension_name" : { "message": "BWNT - New Tab" },
+	"extension_description" : { "message": "Gorgeous minimalistic black & white New Tab Page." },
+
+	"day_monday" : { "message": "Monday" },
+	"day_tuesday" : { "message": "Tuesday" },
+	"day_wednesday" : { "message": "Wednesday" },
+	"day_thursday" : { "message": "Thursday" },
+	"day_friday" : { "message": "Friday" },
+	"day_saturday" : { "message": "Saturday" },
+	"day_sunday" : { "message": "Sunday" },
+
+	"month_january" : { "message": "January" },
+	"month_february" : { "message": "February" },
+	"month_march" : { "message": "March" },
+	"month_april" : { "message": "April" },
+	"month_may" : { "message": "May" },
+	"month_june" : { "message": "June" },
+	"month_july" : { "message": "July" },
+	"month_august" : { "message": "August" },
+	"month_september" : { "message": "September" },
+	"month_october" : { "message": "October" },
+	"month_november" : { "message": "November" },
+	"month_december" : { "message": "December" }
+}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,0 +1,35 @@
+{
+	"extension_name" : { "message": "BWNT - Nueva Pesta\u00F1a" },
+	"extension_description" : { "message": "Bella y minimalista nueva pesta\u00F1a en blanco y negro." },
+
+	"day_monday" : { "message": "Lunes" },
+	"day_tuesday" : { "message": "Martes" },
+	"day_wednesday" : { "message": "Mi\u00E9rcoles" },
+	"day_thursday" : { "message": "Jueves" },
+	"day_friday" : { "message": "Viernes" },
+	"day_saturday" : { "message": "S\u00E1bado" },
+	"day_sunday" : { "message": "Domingo" },
+
+	"month_january" : { "message": "Enero" },
+	"month_february" : { "message": "Febrero" },
+	"month_march" : { "message": "Marzo" },
+	"month_april" : { "message": "Abril" },
+	"month_may" : { "message": "Mayo" },
+	"month_june" : { "message": "Junio" },
+	"month_july" : { "message": "Julio" },
+	"month_august" : { "message": "Agosto" },
+	"month_september" : { "message": "Septiembre" },
+	"month_october" : { "message": "Octubre" },
+	"month_november" : { "message": "Noviembre" },
+	"month_december" : { "message": "Diciembre" },
+
+	"options_title": { "message" : "Opciones nueva pesta\u00F1a"},
+	"12_hour": { "message" : "12-horas"},
+	"24_hour": { "message" : "24-horas"},
+	"show_date": { "message" : "Mostrar fecha"},
+	"change_theme_daytime": { "message" : "Cambiar el tema seg\u00FAn la hora del d\u00EDa"},
+	"light": { "message" : "Claro"},
+	"night": { "message" : "Noche"},
+	"dark": { "message" : "Oscuro"},
+	"material": { "message" : "Material"}
+}

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', translateDocument);
+
+/**
+ * Translates all elements with the attribute data-i18nid in the document.
+ */
+function translateDocument() {
+	var to_translate = document.querySelectorAll('[data-i18nid]');
+	var json_id, new_text;
+	for(var i=0, length=to_translate.length; i<length; i++) {
+		json_id = to_translate[i].dataset.i18nid;
+		new_text = chrome.i18n.getMessage(json_id);
+		if(new_text !== "")
+			to_translate[i].innerText = new_text;
+	}
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,12 @@
 {
 	"manifest_version": 2,
-	"name": "BWNT - New Tab",
+	"name": "__MSG_extension_name__",
     "short_name": "BWNT",
-	"description": "Gorgeous minimalistic black & white New Tab Page.",
+	"description": "__MSG_extension_description__",
 	"icons": {
 		"128": "icon.png"
 	},
+	"default_locale": "en",
 	"version": "1.3.2",
 	"permissions": [],
 	"chrome_url_overrides": {

--- a/newtab.js
+++ b/newtab.js
@@ -8,8 +8,16 @@ if (localStorage.length != 5) {
 }
 
 // Arrays of month and day names which will be chosen from to build date.
-var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
-var days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+var months = ['month_january', 'month_february', 'month_march', 'month_april', 'month_may', 'month_june', 'month_july', 'month_august', 'month_september', 'month_october', 'month_november', 'month_december'];
+var days = ['day_monday', 'day_tuesday', 'day_wednesday', 'day_thursday', 'day_friday', 'day_saturday','day_sunday'];
+
+function getDayName(dayNumber) {
+	return chrome.i18n.getMessage(days[dayNumber]);
+}
+
+function getMonthName(monthNumber) {
+	return chrome.i18n.getMessage(months[monthNumber]);
+}
 
 function update() {
     // Get the current hour and minute.
@@ -40,7 +48,7 @@ function update() {
     // If date is desired to be shown
 	if (JSON.parse(localStorage.showDate)) {
         // Fill in date
-		document.getElementById('date').innerHTML = days[d.getDay()] + ', ' + months[d.getMonth()] + ' ' + d.getDate();
+		document.getElementById('date').innerHTML =  getDayName(d.getDay())+ ', ' + getMonthName(d.getMonth()) + ' ' + d.getDate();
 	} else {
         // Delete date
 		document.getElementById('date').innerHTML = '';

--- a/options.css
+++ b/options.css
@@ -46,6 +46,15 @@ p, select {
 .switch input:checked + label:after {
     left: 25px;
 }
+.options {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+}
+.options, .options select {
+	text-transform: uppercase;
+}
 section {
     margin-top: 10px;
 }

--- a/options.html
+++ b/options.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>New Tab Options</title>
+    <title data-i18nid="options_title">New Tab Options</title>
     <link rel="stylesheet" href="newtab.css">
     <link rel="stylesheet" href="options.css">
 </head>
@@ -10,33 +10,37 @@
 <body>
     <div id="clock"></div>
     <div id="date"></div>
-    <div class="switch">
-        <p>24-HOUR</p>
-        <input type="checkbox" id="format">
-        <label for="format"></label>
-        <p>12-HOUR</p>
-    </div>
-    <section>
-        <div class="checkbox">
-            <input type="checkbox" id="showDate">
-            <label for="showDate"></label>
-            <p>SHOW DATE
+
+    <section class="options">
+        <div class="switch">
+            <p data-i18nid="24_hour">24-HOUR</p>
+            <input type="checkbox" id="format">
+            <label for="format"></label>
+            <p data-i18nid="12_hour">12-HOUR</p>
         </div>
-        <div class="checkbox">
-            <input type="checkbox" id="cycle">
-            <label for="cycle"></label>
-            <p>CHANGE THEME BY TIME OF DAY</p>
+        <section>
+            <div class="checkbox">
+                <input type="checkbox" id="showDate">
+                <label for="showDate"></label>
+                <p data-i18nid="show_date">SHOW DATE</p>
+            </div>
+            <div class="checkbox">
+                <input type="checkbox" id="cycle">
+                <label for="cycle"></label>
+                <p data-i18nid="change_theme_daytime">CHANGE THEME BY TIME OF DAY</p>
+            </div>
+        </section>
+        <div class="select">
+            <select id="theme">
+                <option value="light" data-i18nid="light">LIGHT</option>
+                <option value="night" data-i18nid="night">NIGHT</option>
+                <option value="dark" data-i18nid="dark">DARK</option>
+                <option value="material" data-i18nid="material">MATERIAL</option>
+            </select>
         </div>
     </section>
-    <div class="select">
-        <select id="theme">
-            <option value="light">LIGHT</option>
-            <option value="night">NIGHT</option>
-            <option value="dark">DARK</option>
-            <option value="material">MATERIAL</option>
-        </select>
-    </div>
 
+    <script src="i18n.js"></script>
     <script src="newtab.js"></script>
     <script src="options.js"></script>
 </body>


### PR DESCRIPTION
Chrome provides an API for JS and CSS internationalization, but it does not natively support HTML internationalization so I had to do it manually.

Also I modified a bit of CSS and HTML structure so that strings where not in upper case in the translation files. CSS can upper case it, so options are now inside an _options_ class that applies the upper case.

Also added Spanish translation :-)